### PR TITLE
feat(attribution): Handle second credit table format for PLF

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ These features work together to ensure that amendments are processed accurately 
 To run the full pipeline:
 
 ```bash
-python graal/full_pipeline.py --config=config/default.yaml
+python graal/full_pipeline.py --config=config/default.yml
 # OR
 make run
 ```
@@ -106,7 +106,7 @@ make run
 To run the full pipeline without overwriting work already done in Signale:
 
 ```bash
-python graal/full_pipeline.py --config=config/no_overwrite.yaml
+python graal/full_pipeline.py --config=config/no_overwrite.yml
 # OR
 make run-no-overwrite
 ```
@@ -118,10 +118,10 @@ Each feature mentioned above can be enabled or disabled through the configuratio
 The system uses YAML configuration format:
 
 ```bash
-python graal/full_pipeline.py --config=config/default.yaml
+python graal/full_pipeline.py --config=config/default.yml
 ```
 
-See [config/default.yaml](config/default.yaml) for the configuration we use most of the time.
+See [config/default.yml](config/default.yml) for the configuration we use most of the time.
 
 **Example YAML Configuration**:
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -6,7 +6,7 @@ tf_idf_threshold: 0.4
 
 # Allotment configuration - groups amendments by similarity
 allotments:
-  enabled: false
+  enabled: true
   column: "Corps amdt"  # Column used for similarity comparison
   similarity_threshold: 0.9999  # Threshold above which amendments are considered similar
 
@@ -22,7 +22,7 @@ already_processed_amdt_nums_path: ""
 # Attribution settings
 attribution_interstitial_only: false
 attribution: true
-attribution_project_name: "PLFSS"
+attribution_project_name: "PLF"
 handle_inadmissible_amendments: false
 no_value_overwrite: false
 placeholder_amdt_body: false
@@ -43,10 +43,10 @@ similarity_search:
 summary_generation: false
 
 # Enable default opinion for amendments
-default_opinion: true
+default_opinion: false
 
 # Filter for mission short titles
-mission_short_title_filter: []
+mission_short_title_filter: ["travail"]
 
 # LLM client configuration
 llm_clients:
@@ -57,7 +57,8 @@ llm_clients:
 # File paths configuration
 paths:
   # Path to GRAAL configuration Excel file
-  graal_config_file: "${DATA_FOLDER}/config_graal/Fichier de configuration GRAAL - DSS - latest.xlsx"
+  # graal_config_file: "${DATA_FOLDER}/config_graal/Fichier de configuration GRAAL - DSS - latest.xlsx"
+  graal_config_file: "${DATA_FOLDER}/config_graal/Fichier de configuration GRAAL - PLF - latest.xlsx"
   # Path to preprocessed inadmissible amendments file
   preprocessed_inadmissible_file: "${DATA_FOLDER}/preprocessed/inadmissible_commission.pkl"
   # Path to preprocessed old amendments database
@@ -65,18 +66,20 @@ paths:
 
 # Input files configuration
 input_files:
-  - path: "${DATA_FOLDER}/input_ppl_fin_vie/AN_Commission_PPL_SPA.json"
+  # - path: "${DATA_FOLDER}/input_ppl_fin_vie/AN_Commission_PPL_SPA.json"
+  - path: "${DATA_FOLDER}/input_plf/lecture-senat-2024-2025-143-2-PO78718.json"
     # Default timestamp to use for processing if not specified
     default_processing_timestamp:
       year: 2025
       month: 4
       day: 28
-    origin_project: "PPL Fin de vie 2025"
+    # origin_project: "PPL Fin de vie 2025"
+    origin_project: "PLF 2025"
 
 # Output configuration
 output:
   # Template for output file prefix, includes date formatting
-  file_prefix_template: "${DATA_FOLDER}/résultats_AN_Commission_PPL_SPA_test_%Y-%m-%d"
+  file_prefix_template: "${DATA_FOLDER}/résultats_attribution_PLF_test_%Y-%m-%d"
   # Columns to include in output file
   columns:
     - "Num amdt"
@@ -94,3 +97,4 @@ output:
     - "Exposé amdt"
     - "Corps amdt"
     - "amdt_idx"
+    - "mission_titre_court"

--- a/graal/attribution/matchers/credit_table_matcher.py
+++ b/graal/attribution/matchers/credit_table_matcher.py
@@ -2,7 +2,7 @@
 
 import logging
 import logging.config
-from typing import Any
+from typing import Any, Literal
 
 import pandas as pd
 from bs4 import BeautifulSoup
@@ -12,6 +12,8 @@ from graal.custom_types import AttributionColumns, ColumnName, IntIndex
 from graal.utils.text_utils import AttributionTextNormalizer
 
 logging.config.fileConfig("logging.conf")
+
+TableFormat = Literal["standard", "complex"]
 
 
 class CreditTableMatcher(BaseMatcher):
@@ -33,8 +35,29 @@ class CreditTableMatcher(BaseMatcher):
         self.program_to_attribution = program_to_attribution
         self.allowed_columns = allowed_columns
 
+    def _detect_table_format(self, soup: BeautifulSoup) -> TableFormat:
+        """
+        Detect the format of the HTML table.
+
+        Args:
+            soup: BeautifulSoup object containing the parsed HTML
+
+        Returns:
+            String indicating the detected format: "standard" or "complex"
+        """
+        # Check if the table contains "Crédits de paiement" text (complex format)
+        if soup.find(string=lambda text: text and "Crédits de paiement" in text):
+            return "complex"
+
+        # Check if the table has th elements (standard format)
+        if soup.find("th"):
+            return "standard"
+
+        # Default to standard format if we can't determine
+        return "standard"
+
     def _extract_html_table_as_df(self, html_content: str) -> pd.DataFrame | None:
-        """Extract and parse credit table from HTML content."""
+        """Extract and parse standard credit table from HTML content."""
         # Parse the HTML content
         soup = BeautifulSoup(html_content, "html.parser")
 
@@ -61,6 +84,127 @@ class CreditTableMatcher(BaseMatcher):
         credit_table_df["+"] = credit_table_df["+"].astype(int)
         credit_table_df["-"] = credit_table_df["-"].astype(int)
         return credit_table_df
+
+    def _extract_text_from_cell(self, cell) -> str:
+        """Extract text from a table cell, returning content of first <p> tag if it exists."""
+        p_tags = cell.find_all("p")
+        if p_tags:
+            return p_tags[0].get_text().strip()
+        return cell.get_text().strip()
+
+    def _extract_program_name(self, program_cell) -> str:
+        """Extract program name from a table cell."""
+        progam_text = self._extract_text_from_cell(program_cell)
+        return AttributionTextNormalizer.normalize_text(progam_text)
+
+    def _extract_credit_value(self, cell) -> str:
+        """Extract credit value from a table cell."""
+        try:
+            text = self._extract_text_from_cell(cell)
+            if text and text != " ":
+                return text.replace(" ", "")
+            return "0"
+        except Exception as e:
+            logging.warning(f"Error extracting credit value: {e}")
+            return "0"
+
+    def _create_credit_dataframe(
+        self, programmes, plus_values, minus_values
+    ) -> pd.DataFrame:
+        """Create a DataFrame from extracted credit data and convert values to integers."""
+        data = {"Programmes": programmes, "+": plus_values, "-": minus_values}
+        df = pd.DataFrame(data)
+
+        # Convert "+" and "-" columns to integers, handling non-numeric values
+        for col in ["+", "-"]:
+            df[col] = pd.to_numeric(df[col], errors="coerce").fillna(0).astype(int)
+
+        return df
+
+    def _find_credits_value_indices(self, rows) -> tuple[int, int] | None:
+        """
+        Find the column indices for the "Crédits de paiement" section.
+
+        Args:
+            rows: List of table rows from BeautifulSoup
+
+        Returns:
+            Tuple of (plus_index, minus_index) or None if not found
+        """
+        cells = rows[0].find_all("td")
+        cells = [
+            AttributionTextNormalizer.normalize_text(self._extract_text_from_cell(cell))
+            for cell in cells
+        ]
+        normalized_credit_text = AttributionTextNormalizer.normalize_text(
+            "Crédits de paiement"
+        )
+        # Find the cell containing "Crédits de paiement"
+        for cell_idx, cell_text in enumerate(cells):
+            if normalized_credit_text in cell_text:
+                return cell_idx * 2 - 1, cell_idx * 2
+        return None
+
+    def _extract_complex_html_table_as_df(
+        self, html_content: str
+    ) -> pd.DataFrame | None:
+        """Extract and parse complex credit table with 'Crédits de paiement' section."""
+        soup = BeautifulSoup(html_content, "html.parser")
+
+        table = soup.find("table")
+        if table is None:
+            return None
+
+        # Find all rows
+        rows = table.find_all("tr")
+        if (
+            len(rows) < 3
+        ):  # Need at least header row, column names row, and one data row
+            return None
+
+        # Find the column indices for "Crédits de paiement" section dynamically
+        indices = self._find_credits_value_indices(rows)
+
+        if indices is None:
+            return None
+        credits_plus_idx, credits_minus_idx = indices
+
+        # Extract program names and credit values
+        programmes = []
+        plus_values = []
+        minus_values = []
+
+        # Process data rows, skipping header rows and TOTAL/SOLDE rows
+        for row in rows[2:]:  # Skip header rows
+            cells = row.find_all("td")
+
+            if len(cells) <= 1:
+                continue
+
+            # Get the program name from the first column
+            program_text = self._extract_program_name(cells[0])
+
+            # Skip rows that don't have a proper program name or are TOTAL/SOLDE rows
+            if not program_text or program_text.lower() in ["total", "solde"]:
+                continue
+
+            programmes.append(program_text)
+
+            # Extract "+" value from the Crédits de paiement section
+            plus_value = "0"  # Default to 0
+            if len(cells) > credits_plus_idx:
+                plus_value = self._extract_credit_value(cells[credits_plus_idx])
+
+            # Extract "-" value from the Crédits de paiement section
+            minus_value = "0"  # Default to 0
+            if len(cells) > credits_minus_idx:
+                minus_value = self._extract_credit_value(cells[credits_minus_idx])
+
+            plus_values.append(plus_value)
+            minus_values.append(minus_value)
+
+        # Create DataFrame with the same structure as the standard format
+        return self._create_credit_dataframe(programmes, plus_values, minus_values)
 
     def _normalize_programme_table(self, df: pd.DataFrame) -> pd.DataFrame:
         """Normalize program names and remove totals/balance rows."""
@@ -98,7 +242,6 @@ class CreditTableMatcher(BaseMatcher):
         # Case 2: All zeros in + column, some positive in - column
         if (credit_table["+"] == 0).all() and (credit_table["-"] > 0).any():
             add_possible_attributions(credit_table["-"] > 0)
-
         # Case 3: Positive values in both + and - columns
         if (credit_table["-"] > 0).any():
             add_possible_attributions(credit_table["+"] > 0)
@@ -131,8 +274,23 @@ class CreditTableMatcher(BaseMatcher):
         if column_name not in self.allowed_columns:
             return []
 
-        # Extract and process credit table
-        credit_table = self._extract_html_table_as_df(amendment["Corps amdt original"])
+        # Parse the HTML content
+        html_content = amendment["Corps amdt original"]
+        soup = BeautifulSoup(html_content, "html.parser")
+
+        # Extract the table
+        table = soup.find("table")
+        if table is None:
+            return []
+
+        # Detect table format and extract accordingly
+        table_format = self._detect_table_format(soup)
+
+        if table_format == "complex":
+            credit_table = self._extract_complex_html_table_as_df(html_content)
+        else:
+            credit_table = self._extract_html_table_as_df(html_content)
+
         if credit_table is None:
             return []
 

--- a/makefile
+++ b/makefile
@@ -17,4 +17,4 @@ similarity-db-all:
 	poetry run python graal/utils/build_similarity_db.py
 
 run:
-	python graal/full_pipeline.py --config=config/default.yaml
+	python graal/full_pipeline.py --config=config/default.yml

--- a/tests/unit/attribution/matchers/credit_table_matcher_test.py
+++ b/tests/unit/attribution/matchers/credit_table_matcher_test.py
@@ -5,6 +5,7 @@ import logging.config
 
 import pandas as pd
 import pytest
+from bs4 import BeautifulSoup
 
 from graal.attribution.matchers.credit_table_matcher import CreditTableMatcher
 
@@ -325,3 +326,169 @@ def test_match_credit_both_columns(matcher):
         "programme 456 education nationale",
         "programme 789 recherche",
     }
+
+
+@pytest.fixture
+def complex_credit_table():
+    """Create a complex HTML credit table with 'Crédits de paiement' section."""
+    return """
+    <table>
+        <tbody>
+            <tr>
+                <td>
+                    <p><b>Programmes</b>
+                    </p>
+                </td>
+                <td colspan="2">
+                    <p><b>Autorisations d'engagement</b>
+                    </p>
+                </td>
+                <td colspan="2">
+                    <p><b>Crédits de paiement</b>
+                    </p>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <p> </p>
+                </td>
+                <td>
+                    <p>+</p>
+                </td>
+                <td>
+                    <p>-</p>
+                </td>
+                <td>
+                    <p>+</p>
+                </td>
+                <td>
+                    <p>-</p>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <p><b>Soutien aux prestations de l'aviation civile </b>
+                    </p>
+                    <p>dont titre 2</p>
+                </td>
+                <td>
+                    <p> </p>
+                </td>
+                <td>
+                    <p>9 399 999</p>
+                    <p><i>4 308 111</i>
+                    </p>
+                </td>
+                <td>
+                    <p>9 397 611</p>
+                    <p><i>4 308 569</i>
+                    </p>
+                </td>
+                <td>
+                    <p> </p>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <p><b>Navigation aérienne </b>
+                    </p>
+                </td>
+                <td>
+                    <p> </p>
+                </td>
+                <td>
+                    <p>10 000 000</p>
+                </td>
+                <td>
+                    <p> </p>
+                </td>
+                <td>
+                    <p>5 000 000</p>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <p><b>Transports aériens, surveillance et certification </b>
+                    </p>
+                </td>
+                <td>
+                    <p> </p>
+                </td>
+                <td>
+                    <p>4 200 000</p>
+                </td>
+                <td>
+                    <p> </p>
+                </td>
+                <td>
+                    <p>4 200 000</p>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <p><b>TOTAL</b>
+                    </p>
+                </td>
+                <td>
+                    <p><b> </b>
+                    </p>
+                </td>
+                <td>
+                    <p><b>23 597 611</b>
+                    </p>
+                </td>
+                <td>
+                    <p><b> </b>
+                    </p>
+                </td>
+                <td>
+                    <p><b>18 597 611</b>
+                    </p>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <p><b>SOLDE</b>
+                    </p>
+                </td>
+                <td colspan="2">
+                    <p><b>- 23 597 611</b>
+                    </p>
+                </td>
+                <td colspan="2">
+                    <p><b>- 18 597 611</b>
+                    </p>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    """
+
+
+def test_detect_table_format(matcher, basic_credit_table, complex_credit_table):
+    """Test detection of table format."""
+    # Test standard format detection
+    soup = BeautifulSoup(basic_credit_table, "html.parser")
+    assert matcher._detect_table_format(soup) == "standard"
+
+    # Test complex format detection
+    soup = BeautifulSoup(complex_credit_table, "html.parser")
+    assert matcher._detect_table_format(soup) == "complex"
+
+
+def test_extract_complex_html_table(matcher, complex_credit_table):
+    """Test extracting DataFrame from complex HTML table."""
+    df = matcher._extract_complex_html_table_as_df(complex_credit_table)
+
+    assert isinstance(df, pd.DataFrame)
+    assert list(df.columns) == ["Programmes", "+", "-"]
+    assert len(df) == 3  # 3 program rows (excluding TOTAL and SOLDE)
+    assert df["+"].values.tolist() == [9397611, 0, 0]
+    assert df["-"].values.tolist() == [0, 5000000, 4200000]
+
+    # Check that the correct values were extracted
+    assert "soutien al prestation de l'aviation civile" in df["Programmes"].values[0]
+    assert "navigation aerienne" in df["Programmes"].values[1]
+    assert (
+        "transport aerien, surveillance et certification" in df["Programmes"].values[2]
+    )


### PR DESCRIPTION
I need to handle this new format:

![image](https://github.com/user-attachments/assets/30b93ef2-0d56-432f-b1b7-5f29fc45e429)

I believe we only care about the `Crédits de paiement` part of the table