### PR TITLE
feat: Allow writers to add to existing amdt DBs

### DIFF
--- a/frontend/src/components/DatabaseBuilder/DatabaseBuilder.tsx
+++ b/frontend/src/components/DatabaseBuilder/DatabaseBuilder.tsx
@@ -97,6 +97,15 @@ export const DatabaseBuilder: React.FC = () => {
     refetchInterval: false
   })
 
+  // Query for listing databases the user can append to
+  const { data: appendableDatabaseList, refetch: refetchAppendableDatabases } =
+    useQuery({
+      queryKey: ['appendable-databases'],
+      queryFn: () => apiService.listAppendableDatabases(),
+      enabled: mode === 'append',
+      refetchInterval: false
+    })
+
   // Query for loading manifest in append mode
   const {
     data: manifest,
@@ -193,6 +202,7 @@ export const DatabaseBuilder: React.FC = () => {
       // Refetch database list after build completes (with delay)
       setTimeout(() => {
         void refetchDatabases()
+        void refetchAppendableDatabases()
       }, 2000)
     },
     onError: (error: any) => {
@@ -241,6 +251,7 @@ export const DatabaseBuilder: React.FC = () => {
       // Refetch database list after append completes (with delay)
       setTimeout(() => {
         void refetchDatabases()
+        void refetchAppendableDatabases()
       }, 2000)
     },
     onError: (error: any) => {
@@ -625,7 +636,7 @@ export const DatabaseBuilder: React.FC = () => {
                 }}
               >
                 <option value="">Sélectionner une base de données</option>
-                {databaseList?.databases.map((db) => (
+                {appendableDatabaseList?.databases.map((db) => (
                   <option key={db.name} value={db.name}>
                     {db.name}
                   </option>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -606,6 +606,29 @@ class ApiService {
   }
 
   /**
+   * List databases that the current user can append to (admin, owner, writer)
+   */
+  async listAppendableDatabases(): Promise<DatabaseListResponse> {
+    console.log('[API_CLIENT] Fetching appendable databases')
+
+    try {
+      const response = await this.client.get<DatabaseListResponse>(
+        '/databases/appendable'
+      )
+
+      console.log('[API_CLIENT] Appendable databases retrieved', {
+        total: response.data.total,
+        databases: response.data.databases
+      })
+
+      return response.data
+    } catch (error) {
+      console.error('[API_CLIENT] Failed to fetch appendable databases', error)
+      throw error
+    }
+  }
+
+  /**
    * Delete uploaded file
    */
   async deleteUploadedFile(uploadId: string): Promise<DeleteFileResponse> {

--- a/graal/api/routes/database_builder.py
+++ b/graal/api/routes/database_builder.py
@@ -30,11 +30,13 @@ from graal.api.services.database_builder_service import (
     create_job_id,
 )
 from graal.api.services.database_permission_service import (
+    DbRole,
     get_database_permission_service,
 )
 from graal.api.services.similarity_db_manifest_service import (
     get_similarity_db_manifest_service,
 )
+from graal.database.models import SimilarityDBManifest
 from graal.utils.file_hash_service import get_file_hash_service
 from graal.utils.s3.s3_service import get_s3_service
 
@@ -181,6 +183,52 @@ async def list_databases(
     except Exception as e:
         logging.error(f"[API] Error listing databases: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to list databases") from e
+
+
+@router.get("/appendable", response_model=DatabaseListResponse)
+async def list_appendable_databases(
+    current_user: CurrentUser,
+):
+    """List databases the user can append to (admin, owner, or writer).
+
+    This endpoint is intentionally *role-allowlist* based (owner/writer) for
+    non-admins, rather than hierarchical, to avoid implicitly granting access
+    if new roles are added later.
+    """
+
+    logging.info(
+        "[API] Listing appendable similarity databases for user %s",
+        current_user.user_id,
+    )
+
+    try:
+        manifest_service = get_similarity_db_manifest_service()
+        manifests = await manifest_service.list_active_manifests()
+
+        if not current_user.is_admin:
+            perm_service = get_database_permission_service()
+            appendable_ids = await perm_service.list_databases_for_user_with_roles(
+                current_user.user_id,
+                [DbRole.writer, DbRole.owner],
+            )
+            manifests = [m for m in manifests if str(m.id) in appendable_ids]
+
+        databases = [
+            DatabaseInfo(
+                name=manifest.name,
+                size_bytes=manifest.size_bytes,
+                last_modified=manifest.last_modified,
+            )
+            for manifest in manifests
+        ]
+
+        return DatabaseListResponse(databases=databases, total=len(databases))
+
+    except Exception as e:
+        logging.error("[API] Error listing appendable databases: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=500, detail="Failed to list appendable databases"
+        ) from e
 
 
 @router.post("/upload-file", response_model=FileUploadResponse)
@@ -425,7 +473,9 @@ async def delete_uploaded_file(upload_id: str, _admin_user: AdminUser = None):
         raise HTTPException(status_code=500, detail="Failed to delete file") from e
 
 
-def _find_manifest_by_name(all_manifests: list, database_name: str):
+def _find_manifest_by_name(
+    all_manifests: list[SimilarityDBManifest], database_name: str
+) -> SimilarityDBManifest:
     """Find manifest by database name.
 
     Args:
@@ -433,7 +483,7 @@ def _find_manifest_by_name(all_manifests: list, database_name: str):
         database_name: Name of the database to find
 
     Returns:
-        The matching manifest or None
+        The matching manifest.
 
     Raises:
         HTTPException: If manifest not found
@@ -553,6 +603,26 @@ async def append_to_database(
         all_manifests = await pg_manifest_service.list_active_manifests()
         manifest = _find_manifest_by_name(all_manifests, database_name)
 
+        # Defensive: _find_manifest_by_name currently raises if missing.
+        # Keep this guard to fail fast if behavior changes in the future.
+        if manifest is None:  # pragma: no cover
+            raise HTTPException(
+                status_code=404,
+                detail=f"Database '{database_name}' not found. Create it first using the build endpoint.",
+            )
+
+        # Authorization: admin OR explicit role allowlist (owner/writer)
+        if not current_user.is_admin:
+            perm_service = get_database_permission_service()
+            user_role = await perm_service.get_user_role(
+                str(manifest.id), current_user.user_id
+            )
+            if user_role not in {DbRole.owner, DbRole.writer}:
+                raise HTTPException(
+                    status_code=403,
+                    detail="Insufficient permissions to append to this database",
+                )
+
         logging.info(f"[API] Loaded PostgreSQL manifest for {database_name}")
 
         # Convert new file references to metadata format
@@ -631,7 +701,7 @@ async def append_to_database(
 
 
 @router.get("/{database_name}/manifest", response_model=DatabaseManifestResponse)
-async def get_database_manifest(
+async def get_database_manifest(  # noqa: C901
     database_name: str,
     current_user: CurrentUser,
 ):
@@ -667,6 +737,18 @@ async def get_database_manifest(
 
         if not manifest:
             raise FileNotFoundError(f"No manifest found for database: {database_name}")
+
+        # Authorization: require at least reader role on the DB (or admin)
+        if not current_user.is_admin:
+            perm_service = get_database_permission_service()
+            user_role = await perm_service.get_user_role(
+                str(manifest.id), current_user.user_id
+            )
+            if user_role is None:
+                raise HTTPException(
+                    status_code=403,
+                    detail="Insufficient permissions to view this database manifest",
+                )
 
         logging.info(
             f"[API] Successfully loaded PostgreSQL manifest for: {database_name}"
@@ -714,6 +796,8 @@ async def get_database_manifest(
             status_code=404,
             detail=f"Manifest not found for database '{database_name}'.",
         ) from e
+    except HTTPException:
+        raise
     except Exception as e:
         logging.error(
             f"[API] Error retrieving manifest for {database_name}: {e}", exc_info=True

--- a/graal/api/services/database_permission_service.py
+++ b/graal/api/services/database_permission_service.py
@@ -90,6 +90,31 @@ class DatabasePermissionService:
             )
             return [row[0] for row in result.all()]
 
+    async def list_databases_for_user_with_roles(
+        self, user_id: str, roles: list[DbRoleEnum]
+    ) -> list[str]:
+        """List DB IDs where the user has one of the specified roles.
+
+        Args:
+            user_id: User ID to filter by
+            roles: Allowed roles
+
+        Returns:
+            List of database IDs (as strings)
+        """
+
+        if not roles:
+            return []
+
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(AmendmentDatabasePermission.db_id).where(
+                    AmendmentDatabasePermission.user_id == user_id,
+                    AmendmentDatabasePermission.role.in_(roles),
+                )
+            )
+            return [row[0] for row in result.all()]
+
     async def get_user_by_email(self, email: str) -> Optional[User]:
         """Get user by email address.
 

--- a/tests/unit/api/routes/database_builder_permissions_test.py
+++ b/tests/unit/api/routes/database_builder_permissions_test.py
@@ -1,0 +1,413 @@
+"""Tests for database builder permission enforcement (writer role)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from graal.api.main import app
+from graal.api.services.database_permission_service import DbRole
+from graal.database.enums import DbRoleEnum
+
+
+@pytest.fixture(autouse=True)
+def mock_logging_config(mocker):
+    """Avoid loading real logging.conf in tests."""
+
+    mocker.patch("logging.config.fileConfig")
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    """FastAPI test client."""
+
+    with TestClient(app) as client:
+        yield client
+
+
+@pytest.fixture
+def mock_session_cookie() -> dict[str, str]:
+    return {"Cookie": "session=fake-session"}
+
+
+def _make_manifest(manifest_id: str, name: str):
+    # Minimal manifest interface for the routes under test
+    return SimpleNamespace(
+        id=manifest_id,
+        name=name,
+        size_bytes=123,
+        last_modified=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+        input_files={"files": []},
+    )
+
+
+class TestAppendDatabasePermissions:
+    """Tests for POST /api/v1/databases/{name}/append permission checks."""
+
+    def _patch_auth_as_user(self, user_id: str, is_admin: bool):
+        user = SimpleNamespace(user_id=user_id, is_admin=is_admin)
+        mock_service = AsyncMock()
+        mock_service.get_current_user = AsyncMock(return_value=user)
+        mock_service.require_admin = AsyncMock(return_value=user)
+        return patch(
+            "graal.api.dependencies.auth.get_authorization_service",
+            return_value=mock_service,
+        )
+
+    @pytest.mark.usefixtures("mock_logging_config")
+    def test_append_forbidden_for_reader(self, client: TestClient, mock_session_cookie):
+        manifest = _make_manifest(
+            "11111111-1111-1111-1111-111111111111",
+            "DB1",
+        )
+
+        mock_manifest_service = AsyncMock()
+        mock_manifest_service.list_active_manifests = AsyncMock(return_value=[manifest])
+
+        mock_perm_service = AsyncMock()
+        mock_perm_service.get_user_role = AsyncMock(return_value=DbRoleEnum.reader)
+
+        with (
+            self._patch_auth_as_user(
+                user_id="00000000-0000-0000-0000-000000000001",
+                is_admin=False,
+            ),
+            patch(
+                "graal.api.routes.database_builder.get_similarity_db_manifest_service",
+                return_value=mock_manifest_service,
+            ),
+            patch(
+                "graal.api.routes.database_builder.get_database_permission_service",
+                return_value=mock_perm_service,
+            ),
+        ):
+            response = client.post(
+                "/api/v1/databases/DB1/append",
+                headers=mock_session_cookie,
+                json={
+                    "config_file": "Fichier de configuration GRAAL - DSS - latest.xlsx",
+                    "file_references": [
+                        {
+                            "upload_id": "hash1",
+                            "filename": "file.json",
+                            "file_hash": "hash1",
+                            "s3_key": "pool/hash1-file.json",
+                            "metadata": {
+                                "default_processing_timestamp": 1700000000,
+                                "origin_project": "PLFSS 2024",
+                            },
+                        }
+                    ],
+                },
+            )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.usefixtures("mock_logging_config")
+    def test_append_allowed_for_writer(self, client: TestClient, mock_session_cookie):
+        manifest = _make_manifest(
+            "11111111-1111-1111-1111-111111111111",
+            "DB1",
+        )
+
+        mock_manifest_service = AsyncMock()
+        mock_manifest_service.list_active_manifests = AsyncMock(return_value=[manifest])
+
+        mock_perm_service = AsyncMock()
+        mock_perm_service.get_user_role = AsyncMock(return_value=DbRole.writer)
+
+        class DummyJobRegistry:
+            def create_job(self, *args, **kwargs):
+                return None
+
+        class DummyBuilderService:
+            def __init__(self):
+                self.job_registry = DummyJobRegistry()
+
+            async def start_database_build(self, *args, **kwargs):
+                return None
+
+        class DummyPool:
+            async def download_from_input_pool(self, _s3_key: str) -> bytes:
+                return b"dummy"
+
+        class DummyS3Service:
+            def __init__(self):
+                self.pool = DummyPool()
+
+        with (
+            self._patch_auth_as_user(
+                user_id="00000000-0000-0000-0000-000000000001",
+                is_admin=False,
+            ),
+            patch(
+                "graal.api.routes.database_builder.get_similarity_db_manifest_service",
+                return_value=mock_manifest_service,
+            ),
+            patch(
+                "graal.api.routes.database_builder.get_database_permission_service",
+                return_value=mock_perm_service,
+            ),
+            patch(
+                "graal.api.routes.database_builder.get_database_builder_service",
+                return_value=DummyBuilderService(),
+            ),
+            patch(
+                "graal.api.routes.database_builder.get_s3_service",
+                return_value=DummyS3Service(),
+            ),
+        ):
+            response = client.post(
+                "/api/v1/databases/DB1/append",
+                headers=mock_session_cookie,
+                json={
+                    "config_file": "Fichier de configuration GRAAL - DSS - latest.xlsx",
+                    "file_references": [
+                        {
+                            "upload_id": "hash1",
+                            "filename": "file.json",
+                            "file_hash": "hash1",
+                            "s3_key": "pool/hash1-file.json",
+                            "metadata": {
+                                "default_processing_timestamp": 1700000000,
+                                "origin_project": "PLFSS 2024",
+                            },
+                        }
+                    ],
+                },
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        payload = response.json()
+        assert "job_id" in payload
+
+    @pytest.mark.usefixtures("mock_logging_config")
+    def test_append_unknown_database_returns_404(
+        self, client: TestClient, mock_session_cookie
+    ):
+        mock_manifest_service = AsyncMock()
+        mock_manifest_service.list_active_manifests = AsyncMock(return_value=[])
+
+        mock_perm_service = AsyncMock()
+        mock_perm_service.get_user_role = AsyncMock(return_value=DbRoleEnum.writer)
+
+        with (
+            self._patch_auth_as_user(
+                user_id="00000000-0000-0000-0000-000000000001",
+                is_admin=False,
+            ),
+            patch(
+                "graal.api.routes.database_builder.get_similarity_db_manifest_service",
+                return_value=mock_manifest_service,
+            ),
+            patch(
+                "graal.api.routes.database_builder.get_database_permission_service",
+                return_value=mock_perm_service,
+            ),
+        ):
+            response = client.post(
+                "/api/v1/databases/UNKNOWN_DB/append",
+                headers=mock_session_cookie,
+                json={
+                    "config_file": "Fichier de configuration GRAAL - DSS - latest.xlsx",
+                    "file_references": [
+                        {
+                            "upload_id": "hash1",
+                            "filename": "file.json",
+                            "file_hash": "hash1",
+                            "s3_key": "pool/hash1-file.json",
+                            "metadata": {
+                                "default_processing_timestamp": 1700000000,
+                                "origin_project": "PLFSS 2024",
+                            },
+                        }
+                    ],
+                },
+            )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestAppendableDatabases:
+    """Tests for GET /api/v1/databases/appendable."""
+
+    def _patch_auth_as_user(self, user_id: str, is_admin: bool):
+        user = SimpleNamespace(user_id=user_id, is_admin=is_admin)
+        mock_service = AsyncMock()
+        mock_service.get_current_user = AsyncMock(return_value=user)
+        mock_service.require_admin = AsyncMock(return_value=user)
+        return patch(
+            "graal.api.dependencies.auth.get_authorization_service",
+            return_value=mock_service,
+        )
+
+    @pytest.mark.usefixtures("mock_logging_config")
+    def test_lists_only_writer_owner_for_non_admin(
+        self, client: TestClient, mock_session_cookie
+    ):
+        db1 = _make_manifest("11111111-1111-1111-1111-111111111111", "DB1")
+        db2 = _make_manifest("22222222-2222-2222-2222-222222222222", "DB2")
+
+        mock_manifest_service = AsyncMock()
+        mock_manifest_service.list_active_manifests = AsyncMock(return_value=[db1, db2])
+
+        mock_perm_service = AsyncMock()
+        mock_perm_service.list_databases_for_user_with_roles = AsyncMock(
+            return_value=[str(db2.id)]
+        )
+
+        with (
+            self._patch_auth_as_user(
+                user_id="00000000-0000-0000-0000-000000000001",
+                is_admin=False,
+            ),
+            patch(
+                "graal.api.routes.database_builder.get_similarity_db_manifest_service",
+                return_value=mock_manifest_service,
+            ),
+            patch(
+                "graal.api.routes.database_builder.get_database_permission_service",
+                return_value=mock_perm_service,
+            ),
+        ):
+            response = client.get(
+                "/api/v1/databases/appendable",
+                headers=mock_session_cookie,
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert [db["name"] for db in data["databases"]] == ["DB2"]
+
+    @pytest.mark.usefixtures("mock_logging_config")
+    def test_appendable_lists_all_for_admin(
+        self, client: TestClient, mock_session_cookie
+    ):
+        db1 = _make_manifest("11111111-1111-1111-1111-111111111111", "DB1")
+        db2 = _make_manifest("22222222-2222-2222-2222-222222222222", "DB2")
+
+        mock_manifest_service = AsyncMock()
+        mock_manifest_service.list_active_manifests = AsyncMock(return_value=[db1, db2])
+
+        mock_perm_service = AsyncMock()
+        mock_perm_service.list_databases_for_user_with_roles = AsyncMock(
+            return_value=[]
+        )
+
+        with (
+            self._patch_auth_as_user(
+                user_id="00000000-0000-0000-0000-000000000001",
+                is_admin=True,
+            ),
+            patch(
+                "graal.api.routes.database_builder.get_similarity_db_manifest_service",
+                return_value=mock_manifest_service,
+            ),
+            patch(
+                "graal.api.routes.database_builder.get_database_permission_service",
+                return_value=mock_perm_service,
+            ),
+        ):
+            response = client.get(
+                "/api/v1/databases/appendable",
+                headers=mock_session_cookie,
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert [db["name"] for db in data["databases"]] == ["DB1", "DB2"]
+        mock_perm_service.list_databases_for_user_with_roles.assert_not_awaited()
+
+
+class TestDatabaseManifestPermissions:
+    """Tests for GET /api/v1/databases/{name}/manifest permission checks."""
+
+    def _patch_auth_as_user(self, user_id: str, is_admin: bool):
+        user = SimpleNamespace(user_id=user_id, is_admin=is_admin)
+        mock_service = AsyncMock()
+        mock_service.get_current_user = AsyncMock(return_value=user)
+        mock_service.require_admin = AsyncMock(return_value=user)
+        return patch(
+            "graal.api.dependencies.auth.get_authorization_service",
+            return_value=mock_service,
+        )
+
+    @pytest.mark.usefixtures("mock_logging_config")
+    def test_manifest_forbidden_for_user_without_role(
+        self, client: TestClient, mock_session_cookie
+    ):
+        manifest = _make_manifest(
+            "11111111-1111-1111-1111-111111111111",
+            "DB1",
+        )
+
+        mock_manifest_service = AsyncMock()
+        mock_manifest_service.list_active_manifests = AsyncMock(return_value=[manifest])
+
+        mock_perm_service = AsyncMock()
+        mock_perm_service.get_user_role = AsyncMock(return_value=None)
+
+        with (
+            self._patch_auth_as_user(
+                user_id="00000000-0000-0000-0000-000000000001",
+                is_admin=False,
+            ),
+            patch(
+                "graal.api.routes.database_builder.get_similarity_db_manifest_service",
+                return_value=mock_manifest_service,
+            ),
+            patch(
+                "graal.api.routes.database_builder.get_database_permission_service",
+                return_value=mock_perm_service,
+            ),
+        ):
+            response = client.get(
+                "/api/v1/databases/DB1/manifest",
+                headers=mock_session_cookie,
+            )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.usefixtures("mock_logging_config")
+    def test_manifest_allowed_for_reader(self, client: TestClient, mock_session_cookie):
+        manifest = _make_manifest(
+            "11111111-1111-1111-1111-111111111111",
+            "DB1",
+        )
+
+        mock_manifest_service = AsyncMock()
+        mock_manifest_service.list_active_manifests = AsyncMock(return_value=[manifest])
+
+        mock_perm_service = AsyncMock()
+        mock_perm_service.get_user_role = AsyncMock(return_value=DbRoleEnum.reader)
+
+        with (
+            self._patch_auth_as_user(
+                user_id="00000000-0000-0000-0000-000000000001",
+                is_admin=False,
+            ),
+            patch(
+                "graal.api.routes.database_builder.get_similarity_db_manifest_service",
+                return_value=mock_manifest_service,
+            ),
+            patch(
+                "graal.api.routes.database_builder.get_database_permission_service",
+                return_value=mock_perm_service,
+            ),
+        ):
+            response = client.get(
+                "/api/v1/databases/DB1/manifest",
+                headers=mock_session_cookie,
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["database_name"] == "DB1"
+        assert data["total_files"] == 0


### PR DESCRIPTION
You should only be able to append to DBs if you are either admin, owner, or writer on said DB